### PR TITLE
Fix/venv directory

### DIFF
--- a/o3/zsh/commands.py
+++ b/o3/zsh/commands.py
@@ -14,7 +14,7 @@ class TerminalCommandExecutor:
     def _generate_commands(self):
         return [
             f"gnome-terminal --tab -- {self.shell} -c 'cd {self.project_path}; ssh nsdev-mum-vpn; exec {self.shell}'",
-            f"gnome-terminal --tab -- {self.shell} -c 'cd {self.project_path}; source venv/bin/activate; \
+            f"gnome-terminal --tab -- {self.shell} -c 'cd {self.project_path}; source .venv/bin/activate; \
                    if [ -z \"$VIRTUAL_ENV\" ]; then echo \"Failed to activate venv\"; else echo \"venv activated\"; fi; \
                    python manage.py runserver; exec {self.shell}'",
             f"gnome-terminal --tab -- {self.shell} -c 'cd {self.project_path}; {self.nvm_source} nvm use 14.21.3 && npm run dev; exec {self.shell}'",


### PR DESCRIPTION
Previously, by mistake, .venv directory was used for a virtual environment purpose.

In this commit, used the '.venv' directory.